### PR TITLE
Set working dir for mix deps directly in the command struct

### DIFF
--- a/src/mix.rs
+++ b/src/mix.rs
@@ -1,22 +1,15 @@
 use crate::errors::SourceServiceError;
 
-use std::env;
-use std::path::Path;
 use std::process::Command;
 
 pub fn fetch_mix_deps(subdir: &str) -> Result<(), SourceServiceError> {
-    let origin = env::current_dir()?;
-    let root = Path::new(subdir);
-
-    env::set_current_dir(root)?;
-
-    Command::new("mix").args(["deps.get"]).output()?;
-
-    env::set_current_dir(origin)?;
+    Command::new("mix")
+        .args(["deps.get"])
+        .current_dir(subdir)
+        .output()?;
 
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Removing unused code due to my lack of knowledge that cwd could be set directly in the command struct